### PR TITLE
use Test::Mock to handle ALIEN_DOWNLOAD_RULE overrides

### DIFF
--- a/t/alien_build_plugin_cleanse_builddir.t
+++ b/t/alien_build_plugin_cleanse_builddir.t
@@ -6,15 +6,16 @@ use Path::Tiny qw( path );
 
 my $alien_file = q|
     use alienfile;
-    use Path::Tiny qw( path );
+
+    plugin 'Test::Mock',
+      probe    => 'share',
+      download => 1,
+      extract  => 1;
 
     share {
       #start_url 'file://TARFILE';
       #plugin 'Download';
       #plugin Extract => 'tar';
-
-      download sub { path('file1')->touch }; 
-      extract sub { path('file2')->touch }; 
 
       plugin 'Cleanse::BuildDir';
       


### PR DESCRIPTION
I'm working on improving the download options for users of `Alien::Build`.  To that end we've added an `ALIEN_DOWNLOAD_RULE` environment variable which will enable stricter checks on request.  The possible values are documented in this trial release of AB:  https://metacpan.org/release/PLICEASE/Alien-Build-2.63_01/view/lib/Alien/Build.pm#download_rule

In the near future I would like to change the default from `warn` to `digest_or_encrypt`.  This unfortunately will break a number of plugins.  (TL;DR to do an extract an Alien will have to either 1. fetch via https, 2. bundle alienized package or 3. provide a cryptographic signature).  Most of the breakage is in tests which haven't previously had to worry about this, even for plugins like this one which aren't really affected.

This PR uses the `Test::Mock` to do a fake download and extract and follows the `digest_or_encrypt` requirements.  (it also works with the stricter, but probably not very useful `digest_and_encrypt`).  It should still work on older versions of AB, as `Test::Mock` has been around for a while.

Please let me know if you have any questions.